### PR TITLE
refactor: keras3 버전 업그레이드

### DIFF
--- a/src/backbone.py
+++ b/src/backbone.py
@@ -5,6 +5,9 @@ from .utils import Preprocess
 from .config import MAX_LEN, CHANNELS, PAD
 import tensorflow as tf
 import keras
+import itertools
+
+MBBLOCK_COUNTER = itertools.count(1)
 
 class ECA(keras.layers.Layer):
     """
@@ -155,10 +158,11 @@ name=None):
     """
 
     if name is None:
-        name = str(keras.backend.get_uid("mbblock"))
+        uid = next(MBBLOCK_COUNTER)
+        name = f"mbblock_{uid}" # str(keras.backend.get_uid("mbblock"))
     # Expansion phase
     def apply(inputs):
-        channels_in = keras.backend.int_shape(inputs)[-1]
+        channels_in = keras.ops.shape(inputs)[-1] # keras.backend.int_shape(inputs)[-1]
         channels_expand = channels_in * expand_ratio
 
         skip = inputs
@@ -188,7 +192,7 @@ name=None):
             x = keras.layers.Dropout(drop_rate, noise_shape=(None,1,1), name=name + '_drop')(x)
 
         if (channels_in == channel_size):
-            x = keras.layers.add([x, skip], name=name + '_add')
+            x = keras.layers.Add(name=name + '_add')([x, skip])
         return x
 
     return apply
@@ -324,7 +328,7 @@ def get_model(max_len=MAX_LEN, dropout_step=0, dim=98, num_classes=5):
     Returns:
         A TensorFlow Keras Model object.
     """
-    inp = keras.Input((max_len, CHANNELS))
+    inp = keras.Input(shape=(max_len, CHANNELS))
     x = keras.layers.Masking(mask_value=PAD,input_shape=(max_len,CHANNELS))(inp) #we don't need masking layer with inference
     #x = inp # 추론 시에는 해당 부분을 주석 처리 하고, 학습 시에는 326(윗) 라인을 주석 처리해야 합니다.
     ksize = 17

--- a/train/gloss_transformer_train.py
+++ b/train/gloss_transformer_train.py
@@ -14,8 +14,8 @@ from load_data.create_dataset import TrainDataLoader, upload_file_to_s3
 
 date_idx = datetime.datetime.now().strftime("%Y_%m_%d_%H-%M-%S")
 base_name = f"sign_language_v2_{date_idx}"
-checkpoint_path = f"checkpoints/{base_name}.h5"
-save_model = f"models/{base_name}.h5"
+checkpoint_path = f"checkpoints/{base_name}.keras"
+save_model = f"models/{base_name}.keras"
 tflite_path = f"models/gloss_transformer_models/{base_name}.tflite"
 
 def train_model(data_path: str, mini_project_name: str):
@@ -35,10 +35,7 @@ def train_model(data_path: str, mini_project_name: str):
     print("\nCreating model...")
     model = get_model(max_len=MAX_LEN, dropout_step=0, dim=OUTPUT_DIM, num_classes=NUM_CLASSES)
 
-    if tf.config.list_physical_devices('GPU'):
-        optimizer = keras.optimizers.legacy.Adam(learning_rate=LEARNING_RATE)
-    else:
-        optimizer = keras.optimizers.Adam(learning_rate=LEARNING_RATE)
+    optimizer = keras.optimizers.Adam(learning_rate=LEARNING_RATE)
 
     loss = keras.losses.SparseCategoricalCrossentropy()
     metrics = ['accuracy']


### PR DESCRIPTION
### 진행 상황 📢
- 기존 레거시 코드를 검증 후 교체
  - `keras.backend.get_uid`에서 keras3은 백엔드가 통합된 관계로 `itertools` 라이브러리를 통해 레이어 카운트를 해주는 것으로 방식을 변경하였음.
  - `keras.backend.int_shape` -> `keras.ops.shape`
  - `keras.layers.add` -> `keras.layers.Add`
  - `keras.Input`은 내부에 shape 옵션을 추가해서 명료화
  - keras3으로 넘어가며 GPU 가속화 분기를 나눌 필요가 없게 느껴져 하나로 합침: `keras.optimizers.Adam`

### 참고 문서 📜
- [keras3 api 문서](https://keras.io/api/)와 [keras2 api 문서](https://keras.io/2/api/) 대조 후 진행

### 첨언 ✒️
- 아직 실행 후 테스트를 진행하지 못했음. AWS S3에서 GCP로 변환되며 코드 확인 및 추가적인 변환이 필요할 듯함.

### 기록 📒
- `requirements.txt` 업데이트 사항 (추후 GCP 업로드 후 최종 수정 예정)
  - [upgrade] pandas 최신버전 & numpy==1.26.4 (둘의 충돌이 있었음)
  - [+] wandb
  - [+] tf-keras (wandb와 keras3 동시사용을 위해 필요; 아니면 wandb가 tensorflow를 사용할 수 없음)
  - [+] boto3 (AWS S3 사용을 위해)
  - [upgrade] keras>=3